### PR TITLE
Move all request handling logic to handler package

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,82 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"github.com/LCaparelli/banking-system/internal/web/handler"
-	"io/ioutil"
-	"log"
 	"net/http"
 )
 
 func main() {
-	http.HandleFunc("/account", accountHandler)
-	http.HandleFunc("/withdraw", withdrawHandler)
-	http.HandleFunc("/deposit", depositHandler)
+	http.HandleFunc("/account", handler.AccountHandler)
+	http.HandleFunc("/withdraw", handler.WithdrawHandler)
+	http.HandleFunc("/deposit", handler.DepositHandler)
 	http.ListenAndServe(":8080", nil)
-}
-
-func reqBody(r *http.Request) ([]byte, error) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil, fmt.Errorf("readAll: %v", err)
-	}
-	return body, nil
-}
-
-func accountHandler(w http.ResponseWriter, r *http.Request) {
-	body, err := reqBody(r)
-	if err != nil {
-		log.Printf("reqBody: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	httpMethod := r.Method
-	switch httpMethod {
-	case "GET":
-		handler.AccountGET(w, body)
-	case "DELETE":
-		handler.AccountDELETE(w, body)
-	case "POST":
-		handler.AccountPOST(w, body)
-	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		// TODO: decide whether should this should be logged and how.
-	}
-}
-
-func withdrawHandler(w http.ResponseWriter, r *http.Request) {
-	body, err := reqBody(r)
-	if err != nil {
-		log.Printf("reqBody: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	httpMethod := r.Method
-	switch httpMethod {
-	case "POST":
-		handler.WithdrawPOST(w, body)
-	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		// TODO: decide whether should this should be logged and how.
-	}
-}
-
-func depositHandler(w http.ResponseWriter, r *http.Request) {
-	body, err := reqBody(r)
-	if err != nil {
-		log.Printf("reqBody: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	httpMethod := r.Method
-	switch httpMethod {
-	case "POST":
-		handler.DepositPOST(w, body)
-	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		// TODO: decide whether should this should be logged and how.
-	}
 }

--- a/internal/web/handler/account.go
+++ b/internal/web/handler/account.go
@@ -13,13 +13,35 @@ var (
 	accountService = service.AccountServiceFactory()
 )
 
-func AccountGET(w http.ResponseWriter, body []byte) {
+func AccountHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := reqBody(r)
+	if err != nil {
+		log.Printf("reqBody: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	httpMethod := r.Method
+	switch httpMethod {
+	case "GET":
+		accountGET(w, body)
+	case "DELETE":
+		accountDELETE(w, body)
+	case "POST":
+		accountPOST(w, body)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		// TODO: decide whether should this should be logged and how.
+	}
+}
+
+func accountGET(w http.ResponseWriter, body []byte) {
 	var req request.AccountGET
 	err, status, respBody := initReq(&req, body)
 	if err != nil {
 		w.WriteHeader(status)
 		if _, err = w.Write(respBody); err != nil {
-			log.Printf("AccountGET: Write: %v", err)
+			log.Printf("accountGET: Write: %v", err)
 		}
 		return
 	}
@@ -28,30 +50,30 @@ func AccountGET(w http.ResponseWriter, body []byte) {
 	if err != nil {
 		// TODO: decide whether this should be 404. If we were getting the ID via URL instead of request body, it would.
 		w.WriteHeader(http.StatusNotFound)
-		log.Printf("AccountGET: GetAccount: %v", err)
+		log.Printf("accountGET: GetAccount: %v", err)
 		return
 	}
 
 	respBody, err = json.Marshal(account)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Printf("AccountGET: Marshal: %v", err)
+		log.Printf("accountGET: Marshal: %v", err)
 		return
 	}
 
 	_, err = w.Write([]byte(respBody))
 	if err != nil {
-		log.Printf("AccountGET: Write: %v", err)
+		log.Printf("accountGET: Write: %v", err)
 	}
 }
 
-func AccountDELETE(w http.ResponseWriter, body []byte) {
+func accountDELETE(w http.ResponseWriter, body []byte) {
 	var req request.AccountDELETE
 	err, status, respBody := initReq(&req, body)
 	if err != nil {
 		w.WriteHeader(status)
 		if _, err = w.Write(respBody); err != nil {
-			log.Printf("AccountDELETE: Write: %v", err)
+			log.Printf("accountDELETE: Write: %v", err)
 		}
 		return
 	}
@@ -59,19 +81,19 @@ func AccountDELETE(w http.ResponseWriter, body []byte) {
 	err = accountService.DeleteAccount(req.Id)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
-		log.Printf("AccountDELETE: DeleteAccount: %v", err)
+		log.Printf("accountDELETE: DeleteAccount: %v", err)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
 }
 
-func AccountPOST(w http.ResponseWriter, body []byte) {
+func accountPOST(w http.ResponseWriter, body []byte) {
 	var req request.AccountPOST
 	err, status, respBody := initReq(&req, body)
 	if err != nil {
 		w.WriteHeader(status)
 		if _, err = w.Write(respBody); err != nil {
-			log.Printf("AccountDELETE: Write: %v", err)
+			log.Printf("accountDELETE: Write: %v", err)
 		}
 		return
 	}
@@ -79,18 +101,18 @@ func AccountPOST(w http.ResponseWriter, body []byte) {
 	id, err := accountService.CreateAccount(req.Name, req.Address, req.Balance)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Printf("AccountDELETE: CreateAccount: %v", err)
+		log.Printf("accountDELETE: CreateAccount: %v", err)
 		return
 	}
 
 	respBody, err = json.Marshal(response.AccountGET{Id: id})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Printf("AccountDELETE: Marshal: %v", err)
+		log.Printf("accountDELETE: Marshal: %v", err)
 		return
 	}
 	_, err = w.Write([]byte(respBody))
 	if err != nil {
-		log.Printf("AccountDELETE: Write: %v", err)
+		log.Printf("accountDELETE: Write: %v", err)
 	}
 }

--- a/internal/web/handler/deposit.go
+++ b/internal/web/handler/deposit.go
@@ -6,25 +6,43 @@ import (
 	"net/http"
 )
 
-func DepositPOST(w http.ResponseWriter, body []byte) {
+func DepositHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := reqBody(r)
+	if err != nil {
+		log.Printf("reqBody: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	httpMethod := r.Method
+	switch httpMethod {
+	case "POST":
+		depositPOST(w, body)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		// TODO: decide whether should this should be logged and how.
+	}
+}
+
+func depositPOST(w http.ResponseWriter, body []byte) {
 	var req request.DepositPOST
 	err, status, respBody := initReq(&req, body)
 	if err != nil {
 		w.WriteHeader(status)
 		if _, err = w.Write(respBody); err != nil {
-			log.Printf("DepositPOST: Write: %v", err)
+			log.Printf("depositPOST: Write: %v", err)
 		}
 		return
 	}
 
 	if _, err = accountService.GetAccount(req.Id); err != nil {
-		log.Printf("DepositPOST: GetAccount: %v", err)
+		log.Printf("depositPOST: GetAccount: %v", err)
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
 	if err = accountService.Deposit(req.Id, req.Amount); err != nil {
-		log.Printf("DepositPOST: Deposit: %v", err)
+		log.Printf("depositPOST: Deposit: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/handler/handler.go
+++ b/internal/web/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/LCaparelli/banking-system/internal/web/request"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -33,4 +34,12 @@ func initReq(req request.Request, body []byte) (error, int, []byte) {
 		return err, http.StatusBadRequest, []byte(err.Error())
 	}
 	return nil, 0, nil
+}
+
+func reqBody(r *http.Request) ([]byte, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("readAll: %v", err)
+	}
+	return body, nil
 }


### PR DESCRIPTION
It doesn't make much sense keeping this logic in cmd, so moving this to
the handler package. This also allows some auxiliary functions to not be
exported.

Resolves #6.

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>