### PR TITLE
Return modified/newly created object as responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,16 @@ For example:
 ```
 The "name" and "address" fields must not be empty. The "balance" field must not be negative.
 
-This always return OK (200) with an empty body.
+This always return OK (200) with the account information as return. For example:
+
+```json
+{
+    "Name": "Lucas Caparelli",
+    "Address": "test, 321",
+    "Balance": 0,
+    "Id": 1
+}
+```
 
 ### /deposit
 To make a deposit issue an HTTP POST. The  body itself is a JSON with an integer ("id") and a decimal ("amount").
@@ -102,7 +111,17 @@ For example:
 ```
 The "id" field must not be negative. The "balance" field must be positive.
 
-If the account with the informed id exists the response status will be OK (200) and the body will be empty.
+If the account with the informed id exists the response status will be OK (200) and the body will contain information regarding the operation's success. The body contains a boolean indicating whether the operation was successful or not ("ok"), a string describing the result ("msg") and a decimal with the current balance ("NewBalance").
+
+In the current business model this operation is always successful. An example response body:
+
+```json
+{
+    "Ok": true,
+    "Msg": "Deposit successful",
+    "NewBalance": 100
+}
+```
 
 If the account does not exist the server responds with NotFound status (404) and the response body is empty.
 
@@ -120,14 +139,15 @@ For example:
 
 The "id" field must not be negative. The "balance" field must be positive.
 
-If the account with the informed id exists the response status will be OK (200) and the body will contain information regarding the operation's success. The body contains a boolean indicating whether the operation was successful or not ("ok") and a string describing the result ("msg").
+If the account with the informed id exists the response status will be OK (200) and the body will contain information regarding the operation's success. The body contains a boolean indicating whether the operation was successful or not ("ok"), a string describing the result ("msg") and a decimal with the current balance ("NewBalance").
 
 For example, if there is enough balance to complete the withdraw:
 
 ```json
 {
     "Ok": true,
-    "Msg": "Successfully withdrew 100.50"
+    "Msg": "Successfully withdrew 100.50",
+    "NewBalance": 0
 }
 ```
 
@@ -136,7 +156,8 @@ If there isn't enough balance:
 ```json
 {
     "Ok": false,
-    "Msg": "Not enough balance to withdraw 100.50"
+    "Msg": "Not enough balance to withdraw 100.50",
+    "NewBalance": 0
 }
 ```
 If the account does not exist the server responds with NotFound status (404) and the response body is empty.
@@ -162,17 +183,17 @@ The following functions are part of the API:
 
   The "id" argument must not be negative.
 
-- `CreateAccount(name, address string, balance float64) (int, error)`
+- `CreateAccount(name, address string, balance float64) (*domain.Account, error)`
 
  The "name" and "address" arguments must not be empty. The "balance" argument must not be negative.
 
-- `Deposit(id int, amount float64) error`
+- `Deposit(id int, amount float64) (float64, error)`
 
-  The "id" argument must not be negative. The "balance" argument must be positive.
+  The "id" argument must not be negative. The "amount" argument must be positive.
 
-- `Withdraw(id int, amount float64) error`
+- `Withdraw(id int, amount float64) (float64, error)`
 
-  The "id" argument must not be negative. The "balance" argument must be positive.
+  The "id" argument must not be negative. The "amount" argument must be positive.
 
 ### Library import
 

--- a/internal/web/handler/account.go
+++ b/internal/web/handler/account.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/LCaparelli/banking-system/internal/service"
 	"github.com/LCaparelli/banking-system/internal/web/request"
-	"github.com/LCaparelli/banking-system/internal/web/response"
 	"log"
 	"net/http"
 )
@@ -60,6 +59,12 @@ func accountGET(w http.ResponseWriter, body []byte) {
 		log.Printf("accountGET: Marshal: %v", err)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write([]byte(respBody))
+	if err != nil {
+		log.Printf("withdrawPOST: Write: %v", err)
+	}
 }
 
 func accountDELETE(w http.ResponseWriter, body []byte) {
@@ -93,14 +98,14 @@ func accountPOST(w http.ResponseWriter, body []byte) {
 		return
 	}
 
-	id, err := accountService.CreateAccount(req.Name, req.Address, req.Balance)
+	account, err := accountService.CreateAccount(req.Name, req.Address, req.Balance)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Printf("accountDELETE: CreateAccount: %v", err)
 		return
 	}
 
-	respBody, err = json.Marshal(response.AccountGET{Id: id})
+	respBody, err = json.Marshal(account)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Printf("accountDELETE: Marshal: %v", err)

--- a/internal/web/handler/deposit.go
+++ b/internal/web/handler/deposit.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"encoding/json"
 	"github.com/LCaparelli/banking-system/internal/web/request"
+	"github.com/LCaparelli/banking-system/internal/web/response"
 	"log"
 	"net/http"
 )
@@ -41,9 +43,23 @@ func depositPOST(w http.ResponseWriter, body []byte) {
 		return
 	}
 
-	if err = accountService.Deposit(req.Id, req.Amount); err != nil {
-		log.Printf("depositPOST: Deposit: %v", err)
+	newBalance, err := accountService.Deposit(req.Id, req.Amount)
+	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("withdrawPOST: Marshal: %v", err)
 		return
+	}
+
+	respBody, err = json.Marshal(response.TransactionPOST{Ok: true, Msg: successDeposit, NewBalance: newBalance})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("withdrawPOST: Marshal: %v", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write([]byte(respBody))
+	if err != nil {
+		log.Printf("withdrawPOST: Write: %v", err)
 	}
 }

--- a/internal/web/handler/handler.go
+++ b/internal/web/handler/handler.go
@@ -10,7 +10,10 @@ import (
 )
 
 const (
-	invalidJSON = "invalid JSON syntax or fields in request body"
+	invalidJSON      = "invalid JSON syntax or fields in request body"
+	notEnoughBalance = "Not enough balance to withdraw %.2f"
+	successWithdraw  = "Successfully withdrew %.2f"
+	successDeposit   = "Deposit successful"
 )
 
 func unmarshalReq(body []byte, req request.Request) error {

--- a/internal/web/handler/withdraw.go
+++ b/internal/web/handler/withdraw.go
@@ -9,11 +9,6 @@ import (
 	"net/http"
 )
 
-const (
-	notEnoughBalance = "Not enough balance to withdraw %.2f"
-	success          = "Successfully withdrew %.2f"
-)
-
 func WithdrawHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := reqBody(r)
 	if err != nil {
@@ -49,13 +44,14 @@ func withdrawPOST(w http.ResponseWriter, body []byte) {
 		return
 	}
 
-	ok, msg := true, fmt.Sprintf(success, req.Amount)
-	if err = accountService.Withdraw(req.Id, req.Amount); err != nil {
+	ok, msg := true, fmt.Sprintf(successWithdraw, req.Amount)
+	newBalance, err := accountService.Withdraw(req.Id, req.Amount)
+	if err != nil {
 		ok = false
 		msg = fmt.Sprintf(notEnoughBalance, req.Amount)
 	}
 
-	respBody, err = json.Marshal(response.WithdrawPOST{Ok: ok, Msg: msg})
+	respBody, err = json.Marshal(response.TransactionPOST{Ok: ok, Msg: msg, NewBalance: newBalance})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Printf("withdrawPOST: Marshal: %v", err)

--- a/internal/web/response/account.go
+++ b/internal/web/response/account.go
@@ -1,5 +1,0 @@
-package response
-
-type AccountGET struct {
-	Id int
-}

--- a/internal/web/response/transaction.go
+++ b/internal/web/response/transaction.go
@@ -1,0 +1,7 @@
+package response
+
+type TransactionPOST struct {
+	Ok         bool
+	Msg        string
+	NewBalance float64
+}

--- a/internal/web/response/withdraw.go
+++ b/internal/web/response/withdraw.go
@@ -1,6 +1,0 @@
-package response
-
-type WithdrawPOST struct {
-	Ok  bool
-	Msg string
-}

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -50,33 +50,35 @@ func DeleteAccount(id int) error {
 	return nil
 }
 
-func CreateAccount(name, address string, balance float64) (int, error) {
+func CreateAccount(name, address string, balance float64) (*domain.Account, error) {
 	if err := validateCreate(name, address, balance); err != nil {
-		return -1, fmt.Errorf("validatecreate: %v", err)
+		return nil, fmt.Errorf("validatecreate: %v", err)
 	}
-	id, err := accountService.CreateAccount(name, address, balance)
+	account, err := accountService.CreateAccount(name, address, balance)
 	if err != nil {
-		return -1, fmt.Errorf("service.createaccount: %v", err)
+		return nil, fmt.Errorf("service.createaccount: %v", err)
 	}
-	return id, nil
+	return account, nil
 }
 
-func Deposit(id int, amount float64) error {
+func Deposit(id int, amount float64) (float64, error) {
 	if err := validateDeposit(id, amount); err != nil {
-		return fmt.Errorf("validatedeposit: %v", err)
+		return -1, fmt.Errorf("validatedeposit: %v", err)
 	}
-	if err := accountService.Deposit(id, amount); err != nil {
-		return fmt.Errorf("service.deposit: %v", err)
+	newBalance, err := accountService.Deposit(id, amount)
+	if err != nil {
+		return newBalance, fmt.Errorf("service.deposit: %v", err)
 	}
-	return nil
+	return newBalance, nil
 }
 
-func Withdraw(id int, amount float64) error {
+func Withdraw(id int, amount float64) (float64, error) {
 	if err := validateWithdraw(id, amount); err != nil {
-		return fmt.Errorf("validatewithdraw: %v", err)
+		return -1, fmt.Errorf("validatewithdraw: %v", err)
 	}
-	if err := accountService.Withdraw(id, amount); err != nil {
-		return fmt.Errorf("service.withdraw: %v", err)
+	newBalance, err := accountService.Withdraw(id, amount)
+	if err != nil {
+		return newBalance, fmt.Errorf("service.withdraw: %v", err)
 	}
-	return nil
+	return newBalance, nil
 }


### PR DESCRIPTION
For now we're still returning only the current balance for the "deposit"
and "withdraw" operation as they can only modify one field of the
account. Returning the whole account in those operations felt too leaky
as the client could be gaining access without enough privilege should
such mechanisms be implemented.

Resolves #10.

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>